### PR TITLE
Multiple tags (breaking API)

### DIFF
--- a/FlacLibSharp.Sandbox/Program.cs
+++ b/FlacLibSharp.Sandbox/Program.cs
@@ -190,12 +190,12 @@ namespace FlacLibSharp.Sandbox
             {
                 using (FlacFile flac = new FlacFile(newFile))
                 {
-                    string artist = flac.VorbisComment["ARTIST"];
-                    string title = flac.VorbisComment.Title;
+                    string artist = flac.VorbisComment["ARTIST"].First;
+                    string title = flac.VorbisComment.Title.First;
                     newArtist = String.Format("{0}_Edited", artist);
                     newTitle = String.Format("{0}_Edited", title);
-                    flac.VorbisComment["ARTIST"] = newArtist;
-                    flac.VorbisComment.Title = newTitle;
+                    flac.VorbisComment["ARTIST"].First = newArtist;
+                    flac.VorbisComment.Title.First = newTitle;
 
                     // Save flac file
                     flac.Save();

--- a/FlacLibSharp.Sandbox/Program.cs
+++ b/FlacLibSharp.Sandbox/Program.cs
@@ -190,12 +190,12 @@ namespace FlacLibSharp.Sandbox
             {
                 using (FlacFile flac = new FlacFile(newFile))
                 {
-                    string artist = flac.VorbisComment["ARTIST"].First;
-                    string title = flac.VorbisComment.Title.First;
+                    string artist = flac.VorbisComment["ARTIST"].Value;
+                    string title = flac.VorbisComment.Title.Value;
                     newArtist = String.Format("{0}_Edited", artist);
                     newTitle = String.Format("{0}_Edited", title);
-                    flac.VorbisComment["ARTIST"].First = newArtist;
-                    flac.VorbisComment.Title.First = newTitle;
+                    flac.VorbisComment["ARTIST"].Value = newArtist;
+                    flac.VorbisComment.Title.Value = newTitle;
 
                     // Save flac file
                     flac.Save();

--- a/FlacLibSharp/FastFlac.cs
+++ b/FlacLibSharp/FastFlac.cs
@@ -62,7 +62,7 @@ namespace FlacLibSharp
         /// <param name="path"></param>
         /// <param name="fieldName"></param>
         /// <returns>The value of the field or an empty string if the field is not available.</returns>
-        public static string GetVorbisField(string path, string fieldName)
+        public static VorbisCommentValues GetVorbisField(string path, string fieldName)
         {
             using (FlacFile flac = new FlacFile(path))
             {
@@ -70,58 +70,58 @@ namespace FlacLibSharp
                 {
                     return flac.VorbisComment[fieldName];
                 }
-                return string.Empty;
+                return new VorbisCommentValues();
             }
         }
 
         /// <summary>
-        /// Gets the artist of the track.
+        /// Gets the first artist of the track.
         /// </summary>
         /// <param name="path"></param>
         /// <returns>Empty string if the track number isn't specified in the metadata</returns>
         public static string GetArtist(string path)
         {
-            return GetVorbisField(path, "ARTIST");
+            return GetVorbisField(path, "ARTIST").First;
         }
         
         /// <summary>
-        /// Gets the title of the track.
+        /// Gets the first title of the track.
         /// </summary>
         /// <param name="path"></param>
         /// <returns>Empty string if the track number isn't specified in the metadata</returns>
         public static string GetTitle(string path)
         {
-            return GetVorbisField(path, "TITLE");
+            return GetVorbisField(path, "TITLE").First;
         }
 
         /// <summary>
-        /// Gets the album name.
+        /// Gets the first album name.
         /// </summary>
         /// <param name="path"></param>
         /// <returns>Empty string if the track number isn't specified in the metadata</returns>
         public static string GetAlbum(string path)
         {
-            return GetVorbisField(path, "ALBUM");
+            return GetVorbisField(path, "ALBUM").First;
         }
 
         /// <summary>
-        /// Gets the track number.
+        /// Gets the first track number.
         /// </summary>
         /// <param name="path"></param>
         /// <returns>Empty string if the track number isn't specified in the metadata</returns>
         public static string GetTrackNumber(string path)
         {
-            return GetVorbisField(path, "TRACKNUMBER");
+            return GetVorbisField(path, "TRACKNUMBER").First;
         }
 
         /// <summary>
-        /// Gets the genre of the track.
+        /// Gets the first genre of the track.
         /// </summary>
         /// <param name="path"></param>
         /// <returns>Empty string if no genre is specified in the metadata.</returns>
         public static string GetGenre(string path)
         {
-            return GetVorbisField(path, "GENRE");
+            return GetVorbisField(path, "GENRE").First;
         }
 
         /// <summary>

--- a/FlacLibSharp/FastFlac.cs
+++ b/FlacLibSharp/FastFlac.cs
@@ -81,7 +81,7 @@ namespace FlacLibSharp
         /// <returns>Empty string if the track number isn't specified in the metadata</returns>
         public static string GetArtist(string path)
         {
-            return GetVorbisField(path, "ARTIST").First;
+            return GetVorbisField(path, "ARTIST").Value;
         }
         
         /// <summary>
@@ -91,7 +91,7 @@ namespace FlacLibSharp
         /// <returns>Empty string if the track number isn't specified in the metadata</returns>
         public static string GetTitle(string path)
         {
-            return GetVorbisField(path, "TITLE").First;
+            return GetVorbisField(path, "TITLE").Value;
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace FlacLibSharp
         /// <returns>Empty string if the track number isn't specified in the metadata</returns>
         public static string GetAlbum(string path)
         {
-            return GetVorbisField(path, "ALBUM").First;
+            return GetVorbisField(path, "ALBUM").Value;
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace FlacLibSharp
         /// <returns>Empty string if the track number isn't specified in the metadata</returns>
         public static string GetTrackNumber(string path)
         {
-            return GetVorbisField(path, "TRACKNUMBER").First;
+            return GetVorbisField(path, "TRACKNUMBER").Value;
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace FlacLibSharp
         /// <returns>Empty string if no genre is specified in the metadata.</returns>
         public static string GetGenre(string path)
         {
-            return GetVorbisField(path, "GENRE").First;
+            return GetVorbisField(path, "GENRE").Value;
         }
 
         /// <summary>

--- a/FlacLibSharp/FlacLibSharp.Test/CreateTests.cs
+++ b/FlacLibSharp/FlacLibSharp.Test/CreateTests.cs
@@ -173,12 +173,12 @@ namespace FlacLibSharp.Test
             {
                 VorbisComment vorbisComment = new VorbisComment();
 
-                vorbisComment.Album = albumName;
-                vorbisComment.Artist = artist;
-                vorbisComment[customTag] = customTagValue;
-                vorbisComment[customTag2] = customTag2Value;
-                vorbisComment.Title = title;
-                vorbisComment[titleTag] = title2;
+                vorbisComment.Album.First = albumName;
+                vorbisComment.Artist.First = artist;
+                vorbisComment[customTag].First = customTagValue;
+                vorbisComment[customTag2].First = customTag2Value;
+                vorbisComment.Title.First = title;
+                vorbisComment[titleTag].First = title2;
 
                 flac.Metadata.Add(vorbisComment);
 
@@ -189,12 +189,12 @@ namespace FlacLibSharp.Test
             {
                 VorbisComment vorbisComment = flac.VorbisComment;
 
-                Assert.AreEqual<string>(albumName, vorbisComment.Album);
-                Assert.AreEqual<string>(artist, vorbisComment.Artist);
-                Assert.AreEqual<string>(customTagValue, vorbisComment[customTag]);
-                Assert.AreEqual<string>(customTag2Value, vorbisComment[customTag2.ToUpper()]);
-                Assert.AreEqual<string>(title2, vorbisComment.Title);
-                Assert.AreEqual<string>(title2, vorbisComment[titleTag]);
+                Assert.AreEqual<string>(albumName, vorbisComment.Album.First);
+                Assert.AreEqual<string>(artist, vorbisComment.Artist.First);
+                Assert.AreEqual<string>(customTagValue, vorbisComment[customTag].First);
+                Assert.AreEqual<string>(customTag2Value, vorbisComment[customTag2.ToUpper()].First);
+                Assert.AreEqual<string>(title2, vorbisComment.Title.First);
+                Assert.AreEqual<string>(title2, vorbisComment[titleTag].First);
             }
         }
 

--- a/FlacLibSharp/FlacLibSharp.Test/CreateTests.cs
+++ b/FlacLibSharp/FlacLibSharp.Test/CreateTests.cs
@@ -173,12 +173,12 @@ namespace FlacLibSharp.Test
             {
                 VorbisComment vorbisComment = new VorbisComment();
 
-                vorbisComment.Album.First = albumName;
-                vorbisComment.Artist.First = artist;
-                vorbisComment[customTag].First = customTagValue;
-                vorbisComment[customTag2].First = customTag2Value;
-                vorbisComment.Title.First = title;
-                vorbisComment[titleTag].First = title2;
+                vorbisComment.Album.Value = albumName;
+                vorbisComment.Artist.Value = artist;
+                vorbisComment[customTag].Value = customTagValue;
+                vorbisComment[customTag2].Value = customTag2Value;
+                vorbisComment.Title.Value = title;
+                vorbisComment[titleTag].Value = title2;
 
                 flac.Metadata.Add(vorbisComment);
 
@@ -189,12 +189,12 @@ namespace FlacLibSharp.Test
             {
                 VorbisComment vorbisComment = flac.VorbisComment;
 
-                Assert.AreEqual<string>(albumName, vorbisComment.Album.First);
-                Assert.AreEqual<string>(artist, vorbisComment.Artist.First);
-                Assert.AreEqual<string>(customTagValue, vorbisComment[customTag].First);
-                Assert.AreEqual<string>(customTag2Value, vorbisComment[customTag2.ToUpper()].First);
-                Assert.AreEqual<string>(title2, vorbisComment.Title.First);
-                Assert.AreEqual<string>(title2, vorbisComment[titleTag].First);
+                Assert.AreEqual<string>(albumName, vorbisComment.Album.Value);
+                Assert.AreEqual<string>(artist, vorbisComment.Artist.Value);
+                Assert.AreEqual<string>(customTagValue, vorbisComment[customTag].Value);
+                Assert.AreEqual<string>(customTag2Value, vorbisComment[customTag2.ToUpper()].Value);
+                Assert.AreEqual<string>(title2, vorbisComment.Title.Value);
+                Assert.AreEqual<string>(title2, vorbisComment[titleTag].Value);
             }
         }
 

--- a/FlacLibSharp/FlacLibSharp.Test/ParseTests.cs
+++ b/FlacLibSharp/FlacLibSharp.Test/ParseTests.cs
@@ -123,18 +123,18 @@ namespace FlacLibSharp.Test
                     if (block.Header.Type == MetadataBlockHeader.MetadataBlockType.VorbisComment)
                     {
                         VorbisComment info = (VorbisComment)block;
-                        Assert.AreEqual("Ziggystar", info["ARTIST"].First);
-                        Assert.AreEqual("Ziggystar", info.Artist.First);
-                        Assert.AreEqual("Roland jx3p demo", info["TITLE"].First);
-                        Assert.AreEqual("Roland jx3p demo", info.Title.First);
-                        Assert.AreEqual("Wiki Commons", info["ALBUM"].First);
-                        Assert.AreEqual("Wiki Commons", info.Album.First);
-                        Assert.AreEqual("2005", info["DATE"].First);
-                        Assert.AreEqual("2005", info.Date.First);
-                        Assert.AreEqual("01", info["TRACKNUMBER"].First);
-                        Assert.AreEqual("01", info.TrackNumber.First);
-                        Assert.AreEqual("Electronic", info["GENRE"].First);
-                        Assert.AreEqual("Electronic", info.Genre.First);
+                        Assert.AreEqual("Ziggystar", info["ARTIST"].Value);
+                        Assert.AreEqual("Ziggystar", info.Artist.Value);
+                        Assert.AreEqual("Roland jx3p demo", info["TITLE"].Value);
+                        Assert.AreEqual("Roland jx3p demo", info.Title.Value);
+                        Assert.AreEqual("Wiki Commons", info["ALBUM"].Value);
+                        Assert.AreEqual("Wiki Commons", info.Album.Value);
+                        Assert.AreEqual("2005", info["DATE"].Value);
+                        Assert.AreEqual("2005", info.Date.Value);
+                        Assert.AreEqual("01", info["TRACKNUMBER"].Value);
+                        Assert.AreEqual("01", info.TrackNumber.Value);
+                        Assert.AreEqual("Electronic", info["GENRE"].Value);
+                        Assert.AreEqual("Electronic", info.Genre.Value);
                         Assert.IsFalse(info.ContainsField("UNEXISTINGKEY"));
                     }
                 }

--- a/FlacLibSharp/FlacLibSharp.Test/ParseTests.cs
+++ b/FlacLibSharp/FlacLibSharp.Test/ParseTests.cs
@@ -123,18 +123,18 @@ namespace FlacLibSharp.Test
                     if (block.Header.Type == MetadataBlockHeader.MetadataBlockType.VorbisComment)
                     {
                         VorbisComment info = (VorbisComment)block;
-                        Assert.AreEqual("Ziggystar", info["ARTIST"]);
-                        Assert.AreEqual("Ziggystar", info.Artist);
-                        Assert.AreEqual("Roland jx3p demo", info["TITLE"]);
-                        Assert.AreEqual("Roland jx3p demo", info.Title);
-                        Assert.AreEqual("Wiki Commons", info["ALBUM"]);
-                        Assert.AreEqual("Wiki Commons", info.Album);
-                        Assert.AreEqual("2005", info["DATE"]);
-                        Assert.AreEqual("2005", info.Date);
-                        Assert.AreEqual("01", info["TRACKNUMBER"]);
-                        Assert.AreEqual("01", info.TrackNumber);
-                        Assert.AreEqual("Electronic", info["GENRE"]);
-                        Assert.AreEqual("Electronic", info.Genre);
+                        Assert.AreEqual("Ziggystar", info["ARTIST"].First);
+                        Assert.AreEqual("Ziggystar", info.Artist.First);
+                        Assert.AreEqual("Roland jx3p demo", info["TITLE"].First);
+                        Assert.AreEqual("Roland jx3p demo", info.Title.First);
+                        Assert.AreEqual("Wiki Commons", info["ALBUM"].First);
+                        Assert.AreEqual("Wiki Commons", info.Album.First);
+                        Assert.AreEqual("2005", info["DATE"].First);
+                        Assert.AreEqual("2005", info.Date.First);
+                        Assert.AreEqual("01", info["TRACKNUMBER"].First);
+                        Assert.AreEqual("01", info.TrackNumber.First);
+                        Assert.AreEqual("Electronic", info["GENRE"].First);
+                        Assert.AreEqual("Electronic", info.Genre.First);
                         Assert.IsFalse(info.ContainsField("UNEXISTINGKEY"));
                     }
                 }

--- a/FlacLibSharp/FlacLibSharp.Test/WriteTests.cs
+++ b/FlacLibSharp/FlacLibSharp.Test/WriteTests.cs
@@ -129,12 +129,12 @@ namespace FlacLibSharp.Test
                 using (FlacFile flac = new FlacFile(newFile))
                 {
                     Assert.IsNotNull(flac.VorbisComment);
-                    string artist = flac.VorbisComment["ARTIST"].First;
-                    string title = flac.VorbisComment.Title.First;
+                    string artist = flac.VorbisComment["ARTIST"].Value;
+                    string title = flac.VorbisComment.Title.Value;
                     newArtist = String.Format("{0}_Edited", artist);
                     newTitle = String.Format("{0}_Edited", title);
-                    flac.VorbisComment["ARTIST"].First = newArtist;
-                    flac.VorbisComment.Title.First = newTitle;
+                    flac.VorbisComment["ARTIST"].Value = newArtist;
+                    flac.VorbisComment.Title.Value = newTitle;
 
                     // Save flac file
                     flac.Save();
@@ -142,8 +142,8 @@ namespace FlacLibSharp.Test
                 using (FlacFile flac = new FlacFile(newFile))
                 {
                     Assert.IsNotNull(flac.VorbisComment);
-                    Assert.AreEqual(newTitle, flac.VorbisComment.Title.First);
-                    Assert.AreEqual(newArtist, flac.VorbisComment.Artist.First);
+                    Assert.AreEqual(newTitle, flac.VorbisComment.Title.Value);
+                    Assert.AreEqual(newArtist, flac.VorbisComment.Artist.Value);
                 }
             }
             finally
@@ -172,15 +172,35 @@ namespace FlacLibSharp.Test
                     flac.VorbisComment["ARTIST"].Add("Aaron");
                     flac.VorbisComment["ARTIST"].Add("dgadelha");
 
+                    flac.VorbisComment["TITLE"] = new VorbisCommentValues(new string[] { "Title A", "Title B", "Title C" });
+
+                    flac.VorbisComment["ALBUM"] = new VorbisCommentValues("Album");
+
                     // Save flac file
                     flac.Save();
                 }
                 using (FlacFile flac = new FlacFile(newFile))
                 {
-                    VorbisCommentValues values = flac.VorbisComment["ARTIST"];
+                    var values = flac.VorbisComment["ARTIST"];
                     Assert.AreEqual(2, values.Count);
                     Assert.AreEqual("Aaron", values[0]);
                     Assert.AreEqual("dgadelha", values[1]);
+
+                    values = flac.VorbisComment["TITLE"];
+                    Assert.AreEqual(3, values.Count);
+                    Assert.AreEqual("Title A", values[0]);
+                    Assert.AreEqual("Title B", values[1]);
+                    Assert.AreEqual("Title C", values[2]);
+
+                    var value = flac.VorbisComment["TITLE"].Value;
+                    Assert.AreEqual("Title A", value);
+
+                    values = flac.VorbisComment["ALBUM"];
+                    Assert.AreEqual(1, values.Count);
+                    Assert.AreEqual("Album", values[0]);
+
+                    value = flac.VorbisComment["ALBUM"].Value;
+                    Assert.AreEqual("Album", value);
                 }
             }
             finally

--- a/FlacLibSharp/FlacLibSharp.Test/WriteTests.cs
+++ b/FlacLibSharp/FlacLibSharp.Test/WriteTests.cs
@@ -129,12 +129,12 @@ namespace FlacLibSharp.Test
                 using (FlacFile flac = new FlacFile(newFile))
                 {
                     Assert.IsNotNull(flac.VorbisComment);
-                    string artist = flac.VorbisComment["ARTIST"];
-                    string title = flac.VorbisComment.Title;
+                    string artist = flac.VorbisComment["ARTIST"].First;
+                    string title = flac.VorbisComment.Title.First;
                     newArtist = String.Format("{0}_Edited", artist);
                     newTitle = String.Format("{0}_Edited", title);
-                    flac.VorbisComment["ARTIST"] = newArtist;
-                    flac.VorbisComment.Title = newTitle;
+                    flac.VorbisComment["ARTIST"].First = newArtist;
+                    flac.VorbisComment.Title.First = newTitle;
 
                     // Save flac file
                     flac.Save();
@@ -142,8 +142,8 @@ namespace FlacLibSharp.Test
                 using (FlacFile flac = new FlacFile(newFile))
                 {
                     Assert.IsNotNull(flac.VorbisComment);
-                    Assert.AreEqual(newTitle, flac.VorbisComment.Title);
-                    Assert.AreEqual(newArtist, flac.VorbisComment.Artist);
+                    Assert.AreEqual(newTitle, flac.VorbisComment.Title.First);
+                    Assert.AreEqual(newArtist, flac.VorbisComment.Artist.First);
                 }
             }
             finally
@@ -168,18 +168,16 @@ namespace FlacLibSharp.Test
             {
                 using (FlacFile flac = new FlacFile(newFile))
                 {
-                    flac.VorbisComment.SetAllValues("ARTIST", 
-                        new VorbisCommentValues
-                        {
-                            "Aaron", "dgadelha"
-                        });
-                    
+                    flac.VorbisComment["ARTIST"] = new VorbisCommentValues();
+                    flac.VorbisComment["ARTIST"].Add("Aaron");
+                    flac.VorbisComment["ARTIST"].Add("dgadelha");
+
                     // Save flac file
                     flac.Save();
                 }
                 using (FlacFile flac = new FlacFile(newFile))
                 {
-                    VorbisCommentValues values = flac.VorbisComment.GetAllValues("ARTIST");
+                    VorbisCommentValues values = flac.VorbisComment["ARTIST"];
                     Assert.AreEqual(2, values.Count);
                     Assert.AreEqual("Aaron", values[0]);
                     Assert.AreEqual("dgadelha", values[1]);

--- a/FlacLibSharp/FlacLibSharp.Test/WriteTests.cs
+++ b/FlacLibSharp/FlacLibSharp.Test/WriteTests.cs
@@ -142,8 +142,47 @@ namespace FlacLibSharp.Test
                 using (FlacFile flac = new FlacFile(newFile))
                 {
                     Assert.IsNotNull(flac.VorbisComment);
-                    Assert.AreEqual(flac.VorbisComment.Title, newTitle);
-                    Assert.AreEqual(flac.VorbisComment.Artist, newArtist);
+                    Assert.AreEqual(newTitle, flac.VorbisComment.Title);
+                    Assert.AreEqual(newArtist, flac.VorbisComment.Artist);
+                }
+            }
+            finally
+            {
+                if (File.Exists(newFile))
+                {
+                    File.Delete(newFile);
+                }
+            }
+        }
+
+        [TestMethod, TestCategory("Write Tests")]
+        public void AddMultipleVorbisFields()
+        {
+            string origFile = @"Data\testfile1.flac";
+            string newFile = @"Data\testfile1_temp.flac";
+            // Tests if we can load up a flac file, update the artist and title in the vorbis comments
+            // save the file and then reload the file and see the changes.
+            FileHelper.GetNewFile(origFile, newFile);
+
+            try
+            {
+                using (FlacFile flac = new FlacFile(newFile))
+                {
+                    flac.VorbisComment.SetAllValues("ARTIST", 
+                        new VorbisCommentValues
+                        {
+                            "Aaron", "dgadelha"
+                        });
+                    
+                    // Save flac file
+                    flac.Save();
+                }
+                using (FlacFile flac = new FlacFile(newFile))
+                {
+                    VorbisCommentValues values = flac.VorbisComment.GetAllValues("ARTIST");
+                    Assert.AreEqual(2, values.Count);
+                    Assert.AreEqual("Aaron", values[0]);
+                    Assert.AreEqual("dgadelha", values[1]);
                 }
             }
             finally

--- a/FlacLibSharp/Metadata/VorbisComment.cs
+++ b/FlacLibSharp/Metadata/VorbisComment.cs
@@ -26,10 +26,18 @@ namespace FlacLibSharp
         }
 
         /// <summary>
+        /// Creates a vorbis comment with the given values.
+        /// </summary>
+        public VorbisCommentValues(IEnumerable<string> values)
+        {
+            this.AddRange(values);
+        }
+
+        /// <summary>
         /// The first value of the list of values.
         /// </summary>
         /// <remarks></remarks>
-        public string First {
+        public string Value {
             get
             {
                 if (this.Count == 0) { return string.Empty; }

--- a/FlacLibSharp/Metadata/VorbisComment.cs
+++ b/FlacLibSharp/Metadata/VorbisComment.cs
@@ -151,6 +151,18 @@ namespace FlacLibSharp
             AddComment(key, value);
         }
 
+        protected void AddComment(string fieldName, VorbisCommentValues values)
+        {
+            if (this.comments.ContainsKey(fieldName))
+            {
+                this.comments[fieldName].AddRange(values);
+            }
+            else
+            {
+                this.comments.Add(fieldName, values);
+            }
+        }
+
         /// <summary>
         /// Adds a comment to the list of vorbis comments.
         /// </summary>
@@ -177,43 +189,26 @@ namespace FlacLibSharp
         /// </summary>
         /// <param name="key">The key of the vorbis comment field.</param>
         /// <returns>The value of the vorbis comment field.</returns>
-        public string this[string key]
+        public VorbisCommentValues this[string key]
         {
             get
             {
-                return this.comments[key].First;
+                if (!this.comments.ContainsKey(key))
+                {
+                    this.comments.Add(key, new VorbisCommentValues());
+                }
+
+                return this.comments[key];
             }
             set
             {
                 if (!this.comments.ContainsKey(key))
                 {
-                    this.comments.Add(key, new VorbisCommentValues(value));
+                    this.comments.Add(key, value);
                 } else
                 {
-                    this.comments[key].First = value;
+                    this.comments[key] = value;
                 }
-            }
-        }
-
-        /// <summary>
-        /// Gets all values for a given field name.
-        /// </summary>
-        public VorbisCommentValues GetAllValues(string key) {
-            return this.comments[key];
-        }
-
-        /// <summary>
-        /// Sets all values for a given field name.
-        /// </summary>
-        public void SetAllValues(string key, VorbisCommentValues values)
-        {
-            if (!this.comments.ContainsKey(key))
-            {
-                this.comments.Add(key, values);
-            }
-            else
-            {
-                this.comments[key] = values;
             }
         }
 
@@ -231,55 +226,54 @@ namespace FlacLibSharp
         /// Gets or sets the Artist if available.
         /// </summary>
         /// <remarks>If not found an empty string is returned.</remarks>
-        public string Artist {
-            get { if (this.ContainsField("ARTIST")) return this["ARTIST"]; else return string.Empty; }
-            set { if (this.ContainsField("ARTIST")) this["ARTIST"] = value; else AddComment("ARTIST", value); }
+        public VorbisCommentValues Artist {
+            get { return this["ARTIST"]; }
+            set { this["ARTIST"] = value; }
         }
 
         /// <summary>
         /// Gets or sets the Title if available.
         /// </summary>
         /// <remarks>If not found an empty string is returned.</remarks>
-        public string Title {
-            get { if (this.ContainsField("TITLE")) return this["TITLE"]; else return string.Empty; }
-            set { if (this.ContainsField("TITLE")) this["TITLE"] = value; else AddComment("TITLE", value); }
+        public VorbisCommentValues Title {
+            get { return this["TITLE"]; }
+            set { this["TITLE"] = value; }
         }
 
         /// <summary>
         /// Gets or sets the Album if available.
         /// </summary>
         /// <remarks>If not found an empty string is returned.</remarks>
-        public string Album {
-            get { if (this.ContainsField("ALBUM")) return this["ALBUM"]; else return string.Empty; }
-            set { if (this.ContainsField("ALBUM")) this["ALBUM"] = value; else AddComment("ALBUM", value); }
+        public VorbisCommentValues Album {
+            get { return this["ALBUM"]; }
+            set { this["ALBUM"] = value; }
         }
 
         /// <summary>
         /// Gets or sets the Date if available.
         /// </summary>
         /// <remarks>If not found an empty string is returned.</remarks>
-        public string Date {
-            get { if (this.ContainsField("DATE")) return this["DATE"]; else return string.Empty; }
-            set { if (this.ContainsField("DATE")) this["DATE"] = value; else AddComment("DATE", value); }
+        public VorbisCommentValues Date {
+            get { return this["DATE"]; }
+            set { this["DATE"] = value; }
         }
 
         /// <summary>
         /// Gets or sets the Tacknumber if available.
         /// </summary>
         /// <remarks>If not found an empty string is returned.</remarks>
-        public string TrackNumber {
-            get { if (this.ContainsField("TRACKNUMBER")) return this["TRACKNUMBER"]; else return string.Empty; }
-            set { if (this.ContainsField("TRACKNUMBER")) this["TRACKNUMBER"] = value; else AddComment("TRACKNUMBER", value); }
+        public VorbisCommentValues TrackNumber {
+            get { return this["TRACKNUMBER"]; }
+            set { this["TRACKNUMBER"] = value; }
         }
 
         /// <summary>
         /// Gets or sets the Genre if available.
         /// </summary>
         /// <remarks>If not found an empty string is returned.</remarks>
-        public string Genre {
-            get { if (this.ContainsField("GENRE")) return this["GENRE"]; else return string.Empty; }
-            set { if (this.ContainsField("GENRE")) this["GENRE"] = value; else AddComment("GENRE", value); }
+        public VorbisCommentValues Genre {
+            get { return this["GENRE"]; }
+            set { this["GENRE"] = value; }
         }
-
     }
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ using (FlacFile file = new FlacFile(@"Data\testfile1.flac"))
     // Access to the VorbisComment IF it exists in the file
     var vorbisComment = file.VorbisComment;
     if (vorbisComment != null) {
-        Console.WriteLine("Artist - Title: {0} - {1}", vorbisComment.Artist, vorbisComment.Title);
+        Console.WriteLine("Artist - Title: {0} - {1}", vorbisComment.Artist.Value, vorbisComment.Title.Value);
     }
     
     // Get all other types of metdata blocks:


### PR DESCRIPTION
Address #28 

This pull request adds support for multiple values in a Vorbis Comment Field.

It breaks the API of 1.0.0. Where you used to do:

```
vorbisComment["ARTIST"] = "ArtistName";
```

You must now do:

```
vorbisComment["ARTIST"].First = "ArtistName";
// OR:
vorbisComment["ARTIST"] = new VorbisCommentValues("ArtistName");
```

Reading is different in a similar way.

Old code:

```
var artistName = vorbisComment["ARTIST"];
```

Is now:

```
string artistName = vorbisComment["ARTIST"].First;
// OR
VorbisCommentValues artistNames = vorbisComment["ARTIST"];
```